### PR TITLE
meeting-reminder: Always evaluate week number as decimal

### DIFF
--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -20,7 +20,7 @@ jobs:
           echo "next_date_iso=$next_date_iso" >> "$GITHUB_OUTPUT"
           echo "next_date_year=$next_date_year" >> "$GITHUB_OUTPUT"
           next_date_week=$(date -d "next Wednesday" "+%V")
-          if [[ $(($next_date_week % 3)) != 0 ]];
+          if [[ $((10#$next_date_week % 3)) != 0 ]];
           then
             echo "::notice::Wrong week, skip sending reminder."
             exit 1


### PR DESCRIPTION
In early weeks of the year `date -d "next Wednesday" "+%V"` returns a number of the form 01..09 which bash interprets as oktal number (base 8). Instead of stripping the leading zero we explicitly evaluate with base 10 aka decimal in the arithmetic expression now.

Error output before was something like this for example:

    08: value too great for base (error token is "08")

Link: https://stackoverflow.com/a/11130324
Link: https://www.gnu.org/software/bash/manual/html_node/Shell-Arithmetic.html